### PR TITLE
Update .conkyrc

### DIFF
--- a/.conkyrc
+++ b/.conkyrc
@@ -51,7 +51,7 @@ default_color b7b7b7
 
 # Allow conky to handle transparency -- all or nothing
 #own_window yes
-#own_window_type conky
+#own_window_type desktop
 #own_window_transparent yes
 
 # Allow compiz to handle transparency manually (you will need to add Conky to compiz)

--- a/.conkyrc
+++ b/.conkyrc
@@ -1,338 +1,351 @@
-###############################################################################
-#	Conky Theme	: InfinitySVG
-#
-#	Updates and SVG by:				Eric Weik
-#	Original Infinity theme by:		Harshit Yadav
-#	Includes lua code:				Clock Rings by londonali1010 (2009)
-#	Feel Free to distribute
-#	For Installation Instructions see README
-#
-#	Colors from haunted.lua and .conkyrc:
-#	b7b7b7 (light grey)
-#	6f6f6f (medium grey)
-#	2c2c2c (dark grey)
-#
-#	4a89a7 (blue)		hardware / memory / root
-#	468626 (blue alt)	
-#	e83737 (red)		swap
-#	46a646 (green)		user / cpu / home
-#	f4732d (orange)		network
-#	ebff46 (yellow)		network
-#	FFA300 (br. orange)	text highlights
-#
-#	Changelog:
-#	 + v1.0.1:	Initial version by Harshit Yadav
-#	 + [All further changes tracked in the git repository.]
-###############################################################################
+conky.config = {
+--##############################################################################
+--#	Conky Theme	: InfinitySVG
+--#
+--#	Updates and SVG by:				Eric Weik
+--#	Original Infinity theme by:		Harshit Yadav
+--#	Includes lua code:				Clock Rings by londonali1010 (2009)
+--#	Feel Free to distribute
+--#	For Installation Instructions see README
+--#
+--#	Colors from haunted.lua and .conkyrc:
+--#	b7b7b7 (light grey)
+--#	6f6f6f (medium grey)
+--#	2c2c2c (dark grey)
+--#
+--#	4a89a7 (blue)		hardware / memory / root
+--#	468626 (blue alt)	
+--#	e83737 (red)		swap
+--#	46a646 (green)		user / cpu / home
+--#	f4732d (orange)		network
+--#	ebff46 (yellow)		network
+--#	FFA300 (br. orange)	text highlights
+--#
+--#	Changelog:
+--#	 + v1.0.1:	Initial version by Harshit Yadav
+--#	 + [All further changes tracked in the git repository.]
+--##############################################################################
 
 
 
-## Conky settings
-background yes
-update_interval 5.0
+--# Conky settings
+	background = false,
+	update_interval = 2.0,
 
-cpu_avg_samples 2
-net_avg_samples 2
+	cpu_avg_samples = 2,
+	net_avg_samples = 2,
 
-override_utf8_locale yes
+	override_utf8_locale = true,
 
-double_buffer yes
-no_buffers yes
+	double_buffer = true,
+	no_buffers = true,
 
-text_buffer_size 2048
+	text_buffer_size = 2048,
 
-#imlib_cache_size 0
+--imlib_cache_size 0
 
-default_color b7b7b7
-
-
-
-## Window specifications
-
-# Allow conky to handle transparency -- all or nothing
-#own_window yes
-#own_window_type desktop
-#own_window_transparent yes
-
-# Allow compiz to handle transparency manually (you will need to add Conky to compiz)
-own_window yes
-own_window_type normal
-own_window_transparent no
-own_window_hints undecorate,sticky,skip_taskbar,skip_pager,below
-
-# Allow conky to handle transparency (with percentages) with a compositor
-# From http://blog.mmassonnet.info/2011/08/xfce-48-with-conky.html)
-#own_window yes
-#window_own_type desktop
-#own_window_hints undecorated,below,sticky,skip_taskbar,skip_pager	# make it behave like it belongs to the desktop
-#own_window_argb_visual yes	# true transparency, a compositor has to be active
-#own_window_argb_value 70	# make the background semi-transparent
+	default_color = '#b7b7b7',
 
 
 
-## This Resolution is set according to the screen resolution of 1920 1080
-## Adjust According to yours
+--# Window specifications
 
-#minimum_size 800 560
-#maximum_width 1366
+-- Allow conky to handle transparency -- all or nothing
+--own_window yes
+--own_window_type desktop
+--own_window_transparent yes
 
-minimum_size 1920 1080
+-- Allow compiz to handle transparency manually (you will need to add Conky to compiz)
+--own_window no
+--own_window_type normal
+--own_window_transparent yes
+--own_window_hints undecorate,sticky,skip_taskbar,skip_pager,below
 
-#alignment top_left
-alignment top_right
-gap_x 0
-gap_y 0
-
-
-
-## Graphics settings
-border_inner_margin 0
-border_outer_margin 0
-
-draw_shades no
-draw_outline no
-draw_borders no
-draw_graph_borders yes
+-- Allow conky to handle transparency (with percentages) with a compositor
+-- From http://blog.mmassonnet.info/2011/08/xfce-48-with-conky.html)
+	own_window = true,
+	own_window_type = 'normal',
+	own_window_hints = 'undecorated,below,sticky,skip_taskbar,skip_pager',-- make it behave like it belongs to the desktop
+	own_window_argb_visual = true,-- true transparency, a compositor has to be active
+	own_window_argb_value = 70,-- make the background semi-transparent
 
 
 
-## Text settings
-use_xft yes
-xftfont caviar dreams:size=8
-xftalpha 0.5
-uppercase no
+--# This Resolution is set according to the screen resolution of 1920 1080
+--# Adjust According to yours
 
-temperature_unit fahrenheit
-#temperature_unit celsius
+--minimum_size 800 560
+--maximum_width 1366
 
+	minimum_width = 1920, minimum_height = 1080,
 
-
-## Lua: load clock rings.
-lua_load ~/.conky/scripts/haunted.lua
-lua_draw_hook_pre clock_rings
+--alignment top_left
+	alignment = 'top_right',
+	gap_x = 0,
+	gap_y = 0,
 
 
 
-## Possible variables to be used:
-#
-# 	Variable          Arguments     Description
+--# Graphics settings
+	border_inner_margin = 0,
+	border_outer_margin = 0,
 
-# 	addr              (interface)   IP address for an interface
-# 	acpiacadapter                   ACPI ac adapter state.                   
-# 	acpifan                         ACPI fan state                           
-# 	acpitemp                        ACPI temperature.                        
-# 	adt746xcpu                      CPU temperature from therm_adt746x       
-# 	adt746xfan                      Fan speed from therm_adt746x             
-# 	alignr            (num)         Right-justify text, with space of N
-# 	alignc                          Align text to centre
-# 	battery           (num)         Remaining capasity in ACPI or APM        
-# 					battery. ACPI battery number can be      
-# 					given as argument (default is BAT0).     
-# 	buffers                         Amount of memory buffered                
-# 	cached                          Amount of memory cached                  
-# 	color             (color)       Change drawing color to color            
-# 	cpu                             CPU usage in percents                    
-# 	cpubar            (height)      Bar that shows CPU usage, height is      
-# 					bar's height in pixels                 
-# 	cpugraph          (height),(width) (gradient colour 1) (gradient colour 2)
-# 					CPU usage graph, with optional colours in hex,
-# 					minus the #.
-# 	downspeed         net           Download speed in kilobytes              
-# 	downspeedf        net           Download speed in kilobytes with one     
-# 					decimal                                  
-# 	downspeedgraph    net (height),(width) (gradient colour 1) (gradient colour 2)
-# 					Download speed graph, colours defined in
-# 					hex, minus the #.
-# 	exec              shell command Executes a shell command and displays    
-# 					the output in conky. warning: this      
-# 					takes a lot more resources than other    
-# 					variables. I'd recommend coding wanted   
-# 					behaviour in C and posting a patch :-).  
-# 	execbar           shell command Same as exec, except if the first value
-# 					return is a value between 0-100, it
-# 					will use that number for a bar.
-# 					The size for the bar is currently fixed,
-# 					but that may change in the future.
-# 	execgraph         shell command Same as execbar, but graphs values
-# 	execi             interval, shell command
-#  					Same as exec but with specific interval. 
-# 					Interval can't be less than              
-# 					update_interval in configuration.        
-#	font		  font		Specify a different font.  Only applies
-#					to one line.
-# 	fs_bar            (height), (fs)Bar that shows how much space is used on 
-# 					a file system. height is the height in   
-# 					pixels. fs is any file on that file      
-# 					system.                                  
-# 	fs_free           (fs)          Free space on a file system available    
-# 					for users.                               
-# 	fs_free_perc      (fs)          Free percentage of space on a file       
-# 					system available for users.              
-# 	fs_size           (fs)          File system size                         
-# 	fs_used           (fs)          File system used space                   
-# 	hr                (height)      Horizontal line, height is the height in 
-# 					pixels                                   
-# 	i2c               (dev), type, n  I2C sensor from sysfs (Linux 2.6). dev   
-# 					may be omitted if you have only one I2C  
-# 					device. type is either in (or vol)       
-# 					meaning voltage, fan meaning fan or
-# 					temp/tempf (first in C, second in F)
-# 					meaning temperature. n is number of the  
-# 					sensor. See /sys/bus/i2c/devices/ on     
-# 					your local computer.                     
-# 	if_running        (process)     if PROCESS is running, display
-# 					everything if_running and the matching $endif
-# 	if_existing       (file)        if FILE exists, display everything between
-# 					if_existing and the matching $endif
-# 	if_mounted        (mountpoint)  if MOUNTPOINT is mounted, display everything between
-# 					if_mounted and the matching $endif
-# 	else                            Text to show if any of the above are not true
-# 	kernel                          Kernel version                          
-# 	linkstatus        (interface)   Get the link status for wireless connections
-# 	loadavg           (1), (2), (3) System load average, 1 is for past 1     
-# 					minute, 2 for past 5 minutes and 3 for   
-# 					past 15 minutes.                         
-# 	machine                         Machine, i686 for example                
-# 	mails                           Mail count in mail spool. You can use    
-# 					program like fetchmail to get mails from 
-# 					some server using your favourite         
-# 					protocol. See also new_mails.            
-# 	mem                             Amount of memory in use                  
-# 	membar            (height)      Bar that shows amount of memory in use   
-# 	memmax                          Total amount of memory                   
-# 	memperc                         Percentage of memory in use
-# 	
-# 	metar_ob_time
-# 	metar_temp
-# 	metar_tempf                     Temp in F
-# 	metar_windchill
-# 	metar_dew_point                 There are a bunch of these
-# 	metar_rh                        and they are self-explanatory
-# 	metar_windspeed
-# 	metar_winddir
-# 	metar_swinddir
-# 	metar_cloud
-# 	metar_u2d_time
-# 	
-# 	ml_upload_counter               total session upload in mb
-# 	ml_download_counter             total session download in mb
-# 	ml_nshared_files                number of shared files
-# 	ml_shared_counter               total session shared in mb, buggy
-# 					in some mldonkey versions
-# 	ml_tcp_upload_rate              tcp upload rate in kb/s
-# 	ml_tcp_download_rate            tcp download rate in kb/s
-# 	ml_udp_upload_rate              udp upload rate in kb/s
-# 	ml_udp_download_rate            udp download rate in kb/s
-# 	ml_ndownloaded_files            number of completed files
-# 	ml_ndownloading_files           number of downloading files
-# 	
-# 	mpd_artist			Artist in current MPD song
-# 					(must be enabled at compile)
-# 	mpd_album			Album in current MPD song
-# 	mpd_bar           (height)      Bar of mpd's progress
-# 	mpd_bitrate                     Bitrate of current song
-# 	mpd_status                      Playing, stopped, et cetera.
-# 	mpd_title			Title of current MPD song
-# 	mpd_vol				MPD's volume
-# 	mpd_elapsed                     Song's elapsed time
-# 	mpd_length                      Song's length
-# 	mpd_percent                     Percent of song's progress
-# 	new_mails                       Unread mail count in mail spool.         
-# 	nodename                        Hostname                                 
-# 	outlinecolor      (color)       Change outline color                     
-# 	pre_exec          shell command Executes a shell command one time before 
-# 					conky displays anything and puts output 
-# 					as text.                                 
-# 	processes                       Total processes (sleeping and running)   
-# 	running_processes               Running processes (not sleeping),        
-# 					requires Linux 2.6                       
-# 	shadecolor        (color)       Change shading color                     
-# 	stippled_hr       (space),      Stippled (dashed) horizontal line        
-# 			(height)        
-# 	swapbar           (height)      Bar that shows amount of swap in use     
-# 	swap                            Amount of swap in use                    
-# 	swapmax                         Total amount of swap                     
-# 	swapperc                        Percentage of swap in use                
-# 	sysname                         System name, Linux for example           
-# 	offset            pixels        Move text over by N pixels
-# 	tail              logfile, lines (interval)
-# 					Displays last N lines of supplied text
-# 					text file.  If interval is not supplied,
-# 					Conky assumes 2x Conky's interval.
-# 					Max of 30 lines.
-# 					Max of 30 lines can be displayed.
-# 	time              (format)      Local time, see man strftime to get more 
-# 					information about format                 
-# 	totaldown         net           Total download, overflows at 4 GB on     
-# 					Linux with 32-bit arch and there doesn't 
-# 					seem to be a way to know how many times  
-# 					it has already done that before conky   
-# 					has started.                            
-# 	top               type, num     This takes arguments in the form:
-# 					top <name> <number>
-# 					Basically, processes are ranked from 
-# 					highest to lowest in terms of cpu
-# 					usage, which is what <num> represents.
-# 					The types are: "name", "pid", "cpu", and
-# 					"mem".
-# 					There can be a max of 10 processes listed.
-# 	top_mem           type, num     Same as top, except sorted by mem usage
-# 					instead of cpu
-# 	totalup           net           Total upload, this one too, may overflow 
-# 	updates                         Number of updates (for debugging)        
-# 	upspeed           net           Upload speed in kilobytes                
-# 	upspeedf          net           Upload speed in kilobytes with one       
-# 					decimal                                  
-# 	upspeedgraph      net (height),(width)  (gradient colour 1) (gradient colour 2)
-# 					Upload speed graph, colours defined in
-# 					hex, minus the #.
-# 	uptime                          Uptime                                   
-# 	uptime_short                    Uptime in a shorter format               
-# 	
-# 	seti_prog                       Seti@home current progress
-# 	seti_progbar      (height)      Seti@home current progress bar
-# 	seti_credit                     Seti@home total user credit
-#
-# variable is given either in format $variable or in ${variable}. Latter
-# allows characters right after the variable and must be used in network
-# stuff because of an argument
+	draw_shades = false,
+	draw_outline = false,
+	draw_borders = false,
+	draw_graph_borders = true,
 
 
 
-# stuff after 'TEXT' will be formatted on screen
-TEXT
+--# Text settings
+	use_xft = true,
+	font = 'caviar dreams:size=8',
+	xftalpha = 0.5,
+	uppercase = false,
+
+--temperature_unit fahrenheit
+	temperature_unit = 'celsius',
+
+
+
+--# Lua: load clock rings.
+	lua_load = '~/.conky/scripts/haunted.lua',
+	lua_draw_hook_pre = 'clock_rings',
+
+
+
+--# Possible variables to be used:
+
+-- 	Variable          Arguments     Description
+
+-- 	addr              (interface)   IP address for an interface
+-- 	acpiacadapter                   ACPI ac adapter state.                   
+-- 	acpifan                         ACPI fan state                           
+-- 	acpitemp                        ACPI temperature.                        
+-- 	adt746xcpu                      CPU temperature from therm_adt746x       
+-- 	adt746xfan                      Fan speed from therm_adt746x             
+-- 	alignr            (num)         Right-justify text, with space of N
+-- 	alignc                          Align text to centre
+-- 	battery           (num)         Remaining capasity in ACPI or APM        
+-- 					battery. ACPI battery number can be      
+-- 					given as argument (default is BAT0).     
+-- 	buffers                         Amount of memory buffered                
+-- 	cached                          Amount of memory cached                  
+-- 	color             (color)       Change drawing color to color            
+-- 	cpu                             CPU usage in percents                    
+-- 	cpubar            (height)      Bar that shows CPU usage, height is      
+-- 					bar's height in pixels                 
+-- 	cpugraph          (height),(width) (gradient colour 1) (gradient colour 2)
+-- 					CPU usage graph, with optional colours in hex,
+-- 					minus the #.
+-- 	downspeed         net           Download speed in kilobytes              
+-- 	downspeedf        net           Download speed in kilobytes with one     
+-- 					decimal                                  
+-- 	downspeedgraph    net (height),(width) (gradient colour 1) (gradient colour 2)
+-- 					Download speed graph, colours defined in
+-- 					hex, minus the #.
+-- 	exec              shell command Executes a shell command and displays    
+-- 					the output in conky. warning: this      
+-- 					takes a lot more resources than other    
+-- 					variables. I'd recommend coding wanted   
+-- 					behaviour in C and posting a patch :-).  
+-- 	execbar           shell command Same as exec, except if the first value
+-- 					return is a value between 0-100, it
+-- 					will use that number for a bar.
+-- 					The size for the bar is currently fixed,
+-- 					but that may change in the future.
+-- 	execgraph         shell command Same as execbar, but graphs values
+-- 	execi             interval, shell command
+--  					Same as exec but with specific interval. 
+-- 					Interval can't be less than              
+-- 					update_interval in configuration.        
+--	font		  font		Specify a different font.  Only applies
+--					to one line.
+-- 	fs_bar            (height), (fs)Bar that shows how much space is used on 
+-- 					a file system. height is the height in   
+-- 					pixels. fs is any file on that file      
+-- 					system.                                  
+-- 	fs_free           (fs)          Free space on a file system available    
+-- 					for users.                               
+-- 	fs_free_perc      (fs)          Free percentage of space on a file       
+-- 					system available for users.              
+-- 	fs_size           (fs)          File system size                         
+-- 	fs_used           (fs)          File system used space                   
+-- 	hr                (height)      Horizontal line, height is the height in 
+-- 					pixels                                   
+-- 	i2c               (dev), type, n  I2C sensor from sysfs (Linux 2.6). dev   
+-- 					may be omitted if you have only one I2C  
+-- 					device. type is either in (or vol)       
+-- 					meaning voltage, fan meaning fan or
+-- 					temp/tempf (first in C, second in F)
+-- 					meaning temperature. n is number of the  
+-- 					sensor. See /sys/bus/i2c/devices/ on     
+-- 					your local computer.                     
+-- 	if_running        (process)     if PROCESS is running, display
+-- 					everything if_running and the matching $endif
+-- 	if_existing       (file)        if FILE exists, display everything between
+-- 					if_existing and the matching $endif
+-- 	if_mounted        (mountpoint)  if MOUNTPOINT is mounted, display everything between
+-- 					if_mounted and the matching $endif
+-- 	else                            Text to show if any of the above are not true
+-- 	kernel                          Kernel version                          
+-- 	linkstatus        (interface)   Get the link status for wireless connections
+-- 	loadavg           (1), (2), (3) System load average, 1 is for past 1     
+-- 					minute, 2 for past 5 minutes and 3 for   
+-- 					past 15 minutes.                         
+-- 	machine                         Machine, i686 for example                
+-- 	mails                           Mail count in mail spool. You can use    
+-- 					program like fetchmail to get mails from 
+-- 					some server using your favourite         
+-- 					protocol. See also new_mails.            
+-- 	mem                             Amount of memory in use                  
+-- 	membar            (height)      Bar that shows amount of memory in use   
+-- 	memmax                          Total amount of memory                   
+-- 	memperc                         Percentage of memory in use
+-- 	
+-- 	metar_ob_time
+-- 	metar_temp
+-- 	metar_tempf                     Temp in F
+-- 	metar_windchill
+-- 	metar_dew_point                 There are a bunch of these
+-- 	metar_rh                        and they are self-explanatory
+-- 	metar_windspeed
+-- 	metar_winddir
+-- 	metar_swinddir
+-- 	metar_cloud
+-- 	metar_u2d_time
+-- 	
+-- 	ml_upload_counter               total session upload in mb
+-- 	ml_download_counter             total session download in mb
+-- 	ml_nshared_files                number of shared files
+-- 	ml_shared_counter               total session shared in mb, buggy
+-- 					in some mldonkey versions
+-- 	ml_tcp_upload_rate              tcp upload rate in kb/s
+-- 	ml_tcp_download_rate            tcp download rate in kb/s
+-- 	ml_udp_upload_rate              udp upload rate in kb/s
+-- 	ml_udp_download_rate            udp download rate in kb/s
+-- 	ml_ndownloaded_files            number of completed files
+-- 	ml_ndownloading_files           number of downloading files
+-- 	
+-- 	mpd_artist			Artist in current MPD song
+-- 					(must be enabled at compile)
+-- 	mpd_album			Album in current MPD song
+-- 	mpd_bar           (height)      Bar of mpd's progress
+-- 	mpd_bitrate                     Bitrate of current song
+-- 	mpd_status                      Playing, stopped, et cetera.
+-- 	mpd_title			Title of current MPD song
+-- 	mpd_vol				MPD's volume
+-- 	mpd_elapsed                     Song's elapsed time
+-- 	mpd_length                      Song's length
+-- 	mpd_percent                     Percent of song's progress
+-- 	new_mails                       Unread mail count in mail spool.         
+-- 	nodename                        Hostname                                 
+-- 	outlinecolor      (color)       Change outline color                     
+-- 	pre_exec          shell command Executes a shell command one time before 
+-- 					conky displays anything and puts output 
+-- 					as text.                                 
+-- 	processes                       Total processes (sleeping and running)   
+-- 	running_processes               Running processes (not sleeping),        
+-- 					requires Linux 2.6                       
+-- 	shadecolor        (color)       Change shading color                     
+-- 	stippled_hr       (space),      Stippled (dashed) horizontal line        
+-- 			(height)        
+-- 	swapbar           (height)      Bar that shows amount of swap in use     
+-- 	swap                            Amount of swap in use                    
+-- 	swapmax                         Total amount of swap                     
+-- 	swapperc                        Percentage of swap in use                
+-- 	sysname                         System name, Linux for example           
+-- 	offset            pixels        Move text over by N pixels
+-- 	tail              logfile, lines (interval)
+-- 					Displays last N lines of supplied text
+-- 					text file.  If interval is not supplied,
+-- 					Conky assumes 2x Conky's interval.
+-- 					Max of 30 lines.
+-- 					Max of 30 lines can be displayed.
+-- 	time              (format)      Local time, see man strftime to get more 
+-- 					information about format                 
+-- 	totaldown         net           Total download, overflows at 4 GB on     
+-- 					Linux with 32-bit arch and there doesn't 
+-- 					seem to be a way to know how many times  
+-- 					it has already done that before conky   
+-- 					has started.                            
+-- 	top               type, num     This takes arguments in the form:
+-- 					top <name> <number>
+-- 					Basically, processes are ranked from 
+-- 					highest to lowest in terms of cpu
+-- 					usage, which is what <num> represents.
+-- 					The types are: "name", "pid", "cpu", and
+-- 					"mem".
+-- 					There can be a max of 10 processes listed.
+-- 	top_mem           type, num     Same as top, except sorted by mem usage
+-- 					instead of cpu
+-- 	totalup           net           Total upload, this one too, may overflow 
+-- 	updates                         Number of updates (for debugging)        
+-- 	upspeed           net           Upload speed in kilobytes                
+-- 	upspeedf          net           Upload speed in kilobytes with one       
+-- 					decimal                                  
+-- 	upspeedgraph      net (height),(width)  (gradient colour 1) (gradient colour 2)
+-- 					Upload speed graph, colours defined in
+-- 					hex, minus the #.
+-- 	uptime                          Uptime                                   
+-- 	uptime_short                    Uptime in a shorter format               
+-- 	
+-- 	seti_prog                       Seti@home current progress
+-- 	seti_progbar      (height)      Seti@home current progress bar
+-- 	seti_credit                     Seti@home total user credit
+
+-- variable is given either in format $variable or in ${variable}. Latter
+-- allows characters right after the variable and must be used in network
+-- stuff because of an argument
+
+
+
+-- stuff after 'TEXT' will be formatted on screen
+};
+
+conky.text = [[
 # Clock and header
- ${offset 700}${color EAEAEA}${font GE Inspira:pixelsize=120}${time %H:%M}${font}${voffset -84}${voffset 10}${color FFA300}${font GE Inspira:pixelsize=42}${time %d} ${voffset -15}${color EAEAEA}${font GE Inspira:pixelsize=22}${time  %B} ${time %Y}${font}${voffset 124}${font GE Inspira:pixelsize=58}${offset -547}${time %A}${font}
-${offset 720}${voffset -100}${font Ubuntu:pixelsize=10}${color FFA300}HD ${offset 9}$color${fs_free /} / ${fs_size /}${offset 30}${color FFA300}RAM ${offset 9}$color$mem / $memmax${offset 30}${color FFA300}CPU ${offset 9}$color${cpu cpu0}%
+${offset 700}${color EAEAEA}${font GE Inspira:pixelsize=120}${time %H:%M}${font}${voffset -84}${voffset 10}${color 73ba25}${font GE Inspira:pixelsize=42}${time %d} ${voffset -15}${color EAEAEA}${font GE Inspira:pixelsize=22}${time  %B} ${time %Y}${font}${voffset 124}${font GE Inspira:pixelsize=58}${offset -547}${time %A}${font}
+${offset 680}${voffset -100}${font Ubuntu:pixelsize=14}${color 73ba25}HD ${offset 9}$color${fs_free /} / ${fs_size /}${offset 30}${color 73ba25}RAM ${offset 9}$color$mem / $memmax${offset 30}${color 73ba25}CPU ${offset 9}$color${cpu cpu0}%
 ${voffset 10}${offset 295}${color 2c2c2c}${hr 4}
-${image ~/.conky/background.png}
+${image ~/.conky/background2.png}
 
 
 # Disk usage node
-${offset 120}${voffset 223}${color 4a89a7}${font Santana:size=8:style=Bold}root$color${font Santana:size=8} : ${offset 16}${fs_used /}/${fs_size /}
-${offset 120}${voffset 12}${color 46a646}${font Santana:size=8:style=Bold}home$color${font Santana:size=8} : ${offset 7}${fs_used /home}/${fs_size /home}$font
-${offset 120}${voffset 12}${color e83737}${font Santana:size=8:style=Bold}swap$color${font Santana:size=8} : ${offset 10}${swap} / ${swapfree}$font
+${offset 120}${voffset 198}${color 4a89a7}${font Santana:size=12:style=Bold}root$color${font Santana:size=12} :${offset 14}${fs_used /}/${fs_size /}
+${offset 120}${voffset 4}${color 46a646}${font Santana:size=12:style=Bold}home$color${font Santana:size=12} :${offset 7}${fs_used /home}/${fs_size /home}$font
+${offset 120}${voffset 4}${color e83737}${font Santana:size=12:style=Bold}swap$color${font Santana:size=12} :${offset 10}${swap} / ${swapfree}$font
 # "Home" node (kernel, etc.)
-${offset 583}${voffset -108}$color${font Santana:size=9:style=Bold}Linux ${kernel} kernel
-${offset 585}${voffset 0}${color 4a89a7}${font Santana:size=8}Uptime : ${offset 9}$color${uptime}
+${offset 663}${voffset -108}$color${font Santana:size=13:style=Bold}Linux ${kernel} kernel
+${offset 665}${voffset 0}${color 4a89a7}${font Santana:size=12}Uptime : ${offset 9}$color${uptime}
 # "User" node (whoami, top process, etc.)
-${offset 833}${voffset -78}$color${font Santana:size=9:style=Bold}${exec whoami}@${nodename}
-${offset 835}${voffset 0}$color${font Santana:size=8}${color 46a646}Top (cpu) :  ${offset 9}$color${top name 5} ${top cpu 5}
-${offset 835}${voffset 0}$color${font Santana:size=8}${color 46a646}Top (RAM) : ${offset 9}$color${top_mem name 5} ${top_mem mem 5}
-${offset 835}${voffset 0}${color 6f6f6f}CPU Usage (${cpu}%) :
-${offset 835}${voffset -2}$color${font Santana:size=8}${color 2c2c2c}${cpugraph 32,200 2c2c2c 46a646}
+${offset 1023}${voffset -98}$color${font Santana:size=13:style=Bold}${exec whoami}@${nodename}
+${offset 1025}${voffset 0}$color${font Santana:size=12}${color 46a646}Top (cpu) :  ${offset 9}$color${top name 5} ${top cpu 5}
+${offset 1025}${voffset 0}$color${font Santana:size=12}${color 46a646}Top (RAM) : ${offset 9}$color${top_mem name 5} ${top_mem mem 5}
+${offset 1025}${voffset 0}${color 6f6f6f}CPU Usage (${cpu}%) :
+${offset 1025}${voffset -2}$color${font Santana:size=12}${color 2c2c2c}${cpugraph 32,200 2c2c2c 46a646}
 # "Network" node (IP, connections, etc.)
-${offset 713}${voffset 88}$color${font Santana:size=9:style=Bold}IP Address : ${addr eth0}
-${offset 715}${voffset 0}$color${font Santana:size=8}TCP Connections : ${tcp_portmon 1 65535 count}
-${offset 715}${voffset 0}${font Santana:size=8}${color f4732d}Down : ${offset 9}$color${downspeed eth0}/s ${offset 8}${color ebff46}Up : ${offset 9}$color${upspeed eth0} /s
-${offset 715}${voffset 0}${color 6f6f6f}${font Santana:size=8}Interface eth0 Usage :
-${offset 715}${voffset -2}$color${font Santana:size=8}${color 2c2c2c}${downspeedgraph eth0 32,200 b7b7b7 f4732d}
-${offset 715}${voffset -5}${color 2c2c2c}${upspeedgraph eth0 32,200 b7b7b7 ebff46}
+${offset 713}${voffset 110}$color${font Santana:size=13:style=Bold}Wifi IP Address : ${addr wlp3s0}
+${offset 715}${voffset 0}$color${font Santana:size=12}TCP Connections : ${tcp_portmon 1 65535 count}
+${offset 715}${voffset 0}${font Santana:size=12}${color f4732d}Down : ${offset 9}$color${downspeed wlp3s0}/s ${offset 8}${color ebff46}Up : ${offset 9}$color${upspeed wlp3s0} /s
+${offset 715}${voffset 0}${color 6f6f6f}${font Santana:size=8}Interface wlp3s0 Usage :
+${offset 715}${voffset -2}$color${font Santana:size=12}${color 2c2c2c}${downspeedgraph wlp3s0 32,200 b7b7b7 f4732d}
+${offset 715}${voffset -5}${color 2c2c2c}${upspeedgraph wlp3s0 32,200 b7b7b7 ebff46}
+
+${offset 713}${voffset 0}$color${font Santana:size=13:style=Bold}IP Address : ${addr enp7s0f3u1u1}
+${offset 715}${voffset 0}$color${font Santana:size=12}TCP Connections : ${tcp_portmon 1 65535 count}
+${offset 715}${voffset 0}${font Santana:size=12}${color f4732d}Down : ${offset 9}$color${downspeed enp7s0f3u1u1}/s ${offset 8}${color ebff46}Up : ${offset 9}$color${upspeed enp7s0f3u1u1} /s
+${offset 715}${voffset 0}${color 6f6f6f}${font Santana:size=8}Interface enp7s0f3u1u1 Usage :
+${offset 715}${voffset -2}$color${font Santana:size=12}${color 2c2c2c}${downspeedgraph enp7s0f3u1u1 32,200 b7b7b7 f4732d}
+${offset 715}${voffset -5}${color 2c2c2c}${upspeedgraph enp7s0f3u1u1 32,200 b7b7b7 ebff46}
+
+
 # Positioning eset for static text examples below
 ${voffset -158}
 # Static text example: Logo
-${offset 120}${color EAEAEA}${font Ubuntu:pixelsize=20}${color f4732d}Ubuntu$color 12.10
+${offset 120}${voffset -50}${color 73ba25}${font Ubuntu:pixelsize=44}${color 73ba25}OpenSuse$color Tumbleweed
 # Static text example: Multi-line
 #${offset 120}$font${color 6f6f6f}random text can go here
 #${offset 120}and here...
 #${offset 120}and here...
+]];


### PR DESCRIPTION
"own_window_type conky" is not recognized and conky falls back to "own_window_type normal" which apparently does not support transparency without the own_window_hints you have in the compiz configuration. 

This means you can either use: 

```
    own_window_type desktop 
```

OR

```
    own_window_type normal 
    own_window_hints undecorate,sticky,skip_taskbar,skip_pager,below
```

Error message:

```
 Conky: /home/drag/.conkyrcRight: 54: config file error
 Conky: window type - normal
```
